### PR TITLE
fixed mismatched list name in get_price function

### DIFF
--- a/02_Web_Scraping_With_Beautiful_Soup/02_webscraping_bs4.ipynb
+++ b/02_Web_Scraping_With_Beautiful_Soup/02_webscraping_bs4.ipynb
@@ -642,8 +642,8 @@
     "                price = 0.0                  \n",
     "            else:\n",
     "                price = float(price)  \n",
-    "        # append the prices to the fish_prices list\n",
-    "        fish_prices.append(\n",
+    "        # append the prices to the lst_name list\n",
+    "        lst_name.append(\n",
     "           price\n",
     "        )\n",
     "    return lst_name"


### PR DESCRIPTION
the argument used in the function get_price was not referenced in the function until the return. The code only worked when supplying the right parameter when calling the function. This should fix that